### PR TITLE
hotfix(about): display link

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,7 +50,7 @@
               Welcome to the South Carolina Gamma Chapter of UPE at Coastal
               Carolina University
             </p>
-            <!-- <a class="btn" href="about.html">About Our Chapter</a> -->
+            <a class="btn" href="about.html">About Our Chapter</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Removed hold on about button link within the home page